### PR TITLE
Update dependencies to latest; adapt to serde_yml 0.0.13 (fixes RUSTSEC-2025-0068)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,23 +7,23 @@ authors = ["Dr.-Ing. Johannes Pohl <johannes.pohl90@gmail.com>"]
 categories = ["parser-implementations", "data-structures"]
 keywords = ["sigma", "sigma-rules", "siem", "detection", "security"]
 readme = "README.md"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jopohl/sigma-rust"
 
 [dependencies]
 base64 = "0.22.1"
-cidr = "0.3.0"
+cidr = "0.3.2"
 regex = "1.11.0"
 serde = { version = "1.0.210", features = ["derive"] }
-serde_yml = "0.0.12"
-strum = { version = "0.26.3", features = ["derive"] }
-thiserror = "1.0.64"
+serde_yml = "0.0.13"
+strum = { version = "0.28.0", features = ["derive"] }
+thiserror = "2.0.18"
 serde_json = { version = "1.0.132", optional = true }
 
 [dev-dependencies]
 walkdir = "2.5.0"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "matching_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ repository = "https://github.com/jopohl/sigma-rust"
 [dependencies]
 base64 = "0.22.1"
 cidr = "0.3.2"
-regex = "1.11.0"
-serde = { version = "1.0.210", features = ["derive"] }
+regex = "1.12.4"
+serde = { version = "1.0.228", features = ["derive"] }
 serde_yml = "0.0.13"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"
-serde_json = { version = "1.0.132", optional = true }
+serde_json = { version = "1.0.150", optional = true }
 
 [dev-dependencies]
 walkdir = "2.5.0"
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 
 [[bench]]
 name = "matching_benchmark"

--- a/benches/matching_benchmark.rs
+++ b/benches/matching_benchmark.rs
@@ -1,6 +1,7 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use serde_json::json;
 use sigma_rust::{check_rule, Event, Rule};
+use std::hint::black_box;
 
 fn rule_match_benchmark(c: &mut Criterion) {
     let rule_yaml = r#"

--- a/src/basevalue.rs
+++ b/src/basevalue.rs
@@ -150,7 +150,17 @@ impl TryFrom<serde_yml::Value> for BaseValue {
     fn try_from(value: serde_yml::Value) -> Result<Self, Self::Error> {
         match value {
             serde_yml::Value::Bool(b) => Ok(Self::Boolean(b)),
-            serde_yml::Value::Number(n) => number!(n),
+            // serde_yml::Number::as_f64() returns f64 directly since 0.0.13,
+            // so the shared number! macro (built for Option<f64>) no longer fits here.
+            serde_yml::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    Ok(Self::Int(i))
+                } else if let Some(u) = n.as_u64() {
+                    Ok(Self::Unsigned(u))
+                } else {
+                    Ok(Self::Float(n.as_f64()))
+                }
+            }
             serde_yml::Value::String(s) => Ok(Self::String(s)),
             serde_yml::Value::Null => Ok(Self::Null),
             _ => Err(ParserError::InvalidYAML(format!("{:?}", value))),
@@ -191,10 +201,22 @@ mod tests {
         );
 
         let yaml = r#"
+        EventID: 9223372036854775807
+"#;
+        let v: serde_yml::Value = serde_yml::from_str(yaml).unwrap();
+        let base_value = BaseValue::try_from(v["EventID"].clone()).unwrap();
+        assert_eq!(base_value, BaseValue::Int(9223372036854775807));
+
+        // The noyalib backend of serde_yml 0.0.13 has no u64 representation:
+        // integers above i64::MAX are parsed as floats (with precision loss).
+        let yaml = r#"
         EventID: 18446744073709551615
 "#;
         let v: serde_yml::Value = serde_yml::from_str(yaml).unwrap();
         let base_value = BaseValue::try_from(v["EventID"].clone()).unwrap();
-        assert_eq!(base_value, BaseValue::Unsigned(18446744073709551615));
+        assert_eq!(
+            base_value,
+            BaseValue::Float(18446744073709551615_u64 as f64)
+        );
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -89,12 +89,12 @@ impl Field {
             }
         }
 
-        if self.modifier.value_transformer.is_some() {
+        if let Some(value_transformer) = self.modifier.value_transformer.as_ref() {
             let mut transformed_values: Vec<FieldValue> = Vec::with_capacity(self.values.len());
 
             for val in &self.values {
                 let s = val.as_string()?;
-                match self.modifier.value_transformer.as_ref().unwrap() {
+                match value_transformer {
                     Base64(utf16) => {
                         transformed_values.push(FieldValue::from(encode_base64(s.as_str(), utf16)))
                     }

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -53,7 +53,7 @@ pub enum RelatedType {
 
 /// The logsource describes the log data on which the detection is meant to be applied to.
 /// It describes the log source, the platform, the application and the type that is required in the detection.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 pub struct Logsource {
     /// The category value is used to select all log files written of a logical group.
     /// This may cover one or more sources of information depending on the system.
@@ -124,6 +124,9 @@ pub struct Rule {
     pub modified: Option<String>,
     /// This section describes the log data on which the detection is meant to be applied to.
     /// It describes the log source, the platform, the application and the type that is required in the detection.
+    /// An empty `logsource:` (YAML null) is treated as a logsource with no fields set,
+    /// matching the behavior of serde_yml before 0.0.13.
+    #[serde(deserialize_with = "logsource_or_null")]
     pub logsource: Logsource,
     /// A set of search-identifiers that represent properties of searches on log data.
     pub detection: Detection,
@@ -146,6 +149,13 @@ pub struct Rule {
     /// Capture any additional fields
     #[serde(flatten)]
     pub custom_fields: HashMap<String, serde_yml::Value>,
+}
+
+fn logsource_or_null<'de, D>(deserializer: D) -> Result<Logsource, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<Logsource>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 impl Rule {
@@ -266,10 +276,13 @@ mod tests {
         }
 
         assert_eq!(rule.detection.get_condition(), "selection".to_string());
-        assert_eq!(rule.custom_fields["custom_field"], "some value");
         assert_eq!(
-            rule.custom_fields["another_custom_field"]["nested"],
-            "nested_value"
+            rule.custom_fields["custom_field"].as_str(),
+            Some("some value")
+        );
+        assert_eq!(
+            rule.custom_fields["another_custom_field"]["nested"].as_str(),
+            Some("nested_value")
         );
 
         let event = Event::from([("field_name", "this")]);

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -26,11 +26,9 @@ impl TryFrom<serde_yml::Mapping> for FieldGroup {
     type Error = ParserError;
     fn try_from(mapping: serde_yml::Mapping) -> Result<Self, Self::Error> {
         let mut fields = vec![];
+        // serde_yml::Mapping is keyed by String since 0.0.13
         for (name, values) in mapping.into_iter() {
-            match name {
-                Value::String(name) => fields.push(Field::from_yaml(name, values)?),
-                _ => return Err(Self::Error::InvalidFieldName(format!("{:?}", name))),
-            }
+            fields.push(Field::from_yaml(name, values)?);
         }
         Ok(Self { fields })
     }

--- a/tests/parse_sigma_main_rules.rs
+++ b/tests/parse_sigma_main_rules.rs
@@ -8,8 +8,10 @@ use walkdir::WalkDir;
 /// resolver turns unquoted leading-zero scalars such as `00000429` into
 /// integers (the previous resolver kept them as strings), and string modifiers
 /// like `contains` reject integer values with a parse error.
+/// Paths are relative to the corpus root, with `/` separators.
 /// Remove entries once the upstream rules quote these values.
-const KNOWN_INCOMPATIBLE_RULES: &[&str] = &["registry_set_susp_keyboard_layout_load.yml"];
+const KNOWN_INCOMPATIBLE_RULES: &[&str] =
+    &["rules/windows/registry/registry_set/registry_set_susp_keyboard_layout_load.yml"];
 
 #[test]
 fn test_parse_sigma_main_rules() {
@@ -22,8 +24,13 @@ fn test_parse_sigma_main_rules() {
     let start = Instant::now();
     for entry in WalkDir::new(sigma_dir).into_iter().filter_map(|e| e.ok()) {
         if entry.path().extension().and_then(|s| s.to_str()) == Some("yml") {
-            let file_name = entry.file_name().to_str().unwrap_or_default();
-            if KNOWN_INCOMPATIBLE_RULES.contains(&file_name) {
+            let relative_path = entry
+                .path()
+                .strip_prefix(sigma_dir)
+                .expect("walked entries live under the corpus root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            if KNOWN_INCOMPATIBLE_RULES.contains(&relative_path.as_str()) {
                 println!("Skipping known incompatible rule {:?}", entry.path());
                 continue;
             }

--- a/tests/parse_sigma_main_rules.rs
+++ b/tests/parse_sigma_main_rules.rs
@@ -4,6 +4,13 @@ use std::io::Read;
 use std::time::Instant;
 use walkdir::WalkDir;
 
+/// Rules that no longer parse since serde_yml 0.0.13: its YAML 1.2 core-schema
+/// resolver turns unquoted leading-zero scalars such as `00000429` into
+/// integers (the previous resolver kept them as strings), and string modifiers
+/// like `contains` reject integer values with a parse error.
+/// Remove entries once the upstream rules quote these values.
+const KNOWN_INCOMPATIBLE_RULES: &[&str] = &["registry_set_susp_keyboard_layout_load.yml"];
+
 #[test]
 fn test_parse_sigma_main_rules() {
     let sigma_dir = "sigma-main-rules";
@@ -15,6 +22,11 @@ fn test_parse_sigma_main_rules() {
     let start = Instant::now();
     for entry in WalkDir::new(sigma_dir).into_iter().filter_map(|e| e.ok()) {
         if entry.path().extension().and_then(|s| s.to_str()) == Some("yml") {
+            let file_name = entry.file_name().to_str().unwrap_or_default();
+            if KNOWN_INCOMPATIBLE_RULES.contains(&file_name) {
+                println!("Skipping known incompatible rule {:?}", entry.path());
+                continue;
+            }
             total += 1;
             let mut file = File::open(entry.path()).expect("Unable to open file");
             let mut contents = String::new();


### PR DESCRIPTION
## Summary

`cargo update` against current crates.io breaks the build with errors like:

```
error[E0599]: no method named `expect` found for type `f64` (src/basevalue.rs:126)
error[E0308]: mismatched types — expected `String`, found `Value` (src/selection.rs:31)
```

The cause is `serde_yml` 0.0.13: `serde_yml` was deprecated after [RUSTSEC-2025-0068](https://rustsec.org/advisories/RUSTSEC-2025-0068.html) flagged all releases ≤ 0.0.12 as unsound (potential segfault via the C-FFI `libyaml` parser), and 0.0.13 is a pure-Rust compatibility shim backed by [`noyalib`](https://crates.io/crates/noyalib) with a few small API deltas. This PR updates every dependency to its latest release and adapts the code:

| Crate | From | To |
| --- | --- | --- |
| serde_yml | 0.0.12 | 0.0.13 (clears RUSTSEC-2025-0068) |
| thiserror | 1.0.64 | 2.0.18 |
| strum | 0.26.3 | 0.28.0 |
| criterion | 0.5 | 0.8.2 |
| cidr | 0.3.0 | 0.3.2 |
| regex | 1.11.0 | 1.12.4 |
| serde | 1.0.210 | 1.0.228 |
| serde_json | 1.0.132 | 1.0.150 |

base64 (0.22.1) and walkdir (2.5.0) were already at their latest releases; every version floor in `Cargo.toml` now matches the newest version on crates.io.

MSRV moves from 1.81 to **1.85** (required by serde_yml 0.0.13).

## Code changes

- `Number::as_f64()` now returns `f64` instead of `Option<f64>` → inlined the float branch in `BaseValue::try_from` (the shared `number!` macro still serves the `serde_json` path, which kept the `Option` API).
- `Mapping` is now keyed by `String` instead of `Value` → simplified `FieldGroup::try_from`.
- Structs no longer deserialize from YAML null → an empty `logsource:` is now explicitly treated as a `Logsource` with no fields set (previous behavior).
- `Value` no longer implements `PartialEq<&str>` → tests compare via `as_str()`.
- `criterion::black_box` is deprecated → use `std::hint::black_box`.
- Fixed a pre-existing `clippy::unnecessary_unwrap` lint that current stable clippy denies under CI's `RUSTFLAGS=-Dwarnings`.

## Behavioral changes from the new YAML backend

Two parser-level deltas flow through from noyalib and cannot be papered over in sigma-rust (the original text is lost before the `Value` DOM is built):

1. **Unquoted leading-zero scalars parse as integers** under the YAML 1.2 core schema: `00000429` → int `429` (previously the string `"00000429"`). Rules using such values with `contains`/`startswith`/`endswith` now fail **loudly at parse time**. Exactly one rule in the SigmaHQ r2024-09-02 corpus is affected ([`registry_set_susp_keyboard_layout_load.yml`](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/registry/registry_set/registry_set_susp_keyboard_layout_load.yml), still unquoted upstream as of r2026-04-01); it is allowlisted in `test_parse_sigma_main_rules` with a comment. Quoting the values upstream fixes it.
2. **No u64 representation**: integers above `i64::MAX` (> 9.2e18) degrade to floats with precision loss. No real-world rule values are anywhere near this range; documented in the `basevalue` test.

Silently coercing numbers to strings for string modifiers was deliberately rejected — `429` stringifies to `"429"`, not the `"00000429"` the rule author wrote, which would match the wrong thing silently instead of failing loudly.

## Validation

- `cargo test` and `cargo test --no-default-features`: all suites green.
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`: clean.
- `cargo fmt --all -- --check`: clean.
- SigmaHQ r2024-09-02 corpus (same zip CI uses): **3039/3040 rules parse** (the one allowlisted rule above fails loudly). Baseline verified on a clean 0.6.0 checkout with serde_yml 0.0.12: 3040/3040.
- Corpus parse time dropped from ~20.2 s to ~0.52 s in debug builds (~40×) with the pure-Rust backend.

## Notes

- `cargo audit` stops flagging RUSTSEC-2025-0068 after this change (relevant to the `audit.yml` workflow).
- If you'd rather not depend on a deprecated shim long-term, the natural follow-up is `noyalib = { version = "0.0.5", features = ["compat-serde-yaml"] }` with `use noyalib::compat::serde_yaml as serde_yml;` — identical surface, same code changes as this PR. Kept as `serde_yml = "0.0.13"` here for the minimal diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
