### PR TITLE
Migrate from the deprecated serde_yml to yaml_serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.22.1"
 cidr = "0.3.2"
 regex = "1.13.1"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_yml = "0.0.12"
+yaml_serde = "0.10.4"
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 serde_json = { version = "1.0.150", optional = true }

--- a/benches/matching_benchmark.rs
+++ b/benches/matching_benchmark.rs
@@ -16,7 +16,7 @@ detection:
     condition: all of them
         "#;
 
-    let rule: Rule = serde_yml::from_str(rule_yaml).unwrap();
+    let rule: Rule = yaml_serde::from_str(rule_yaml).unwrap();
 
     let event: Event = json!( {
         "EventID": 4624,

--- a/examples/detect.rs
+++ b/examples/detect.rs
@@ -34,7 +34,7 @@ falsepositives:
 level: medium
         "#;
 
-    let rule: Rule = serde_yml::from_str(rule_yaml).unwrap();
+    let rule: Rule = yaml_serde::from_str(rule_yaml).unwrap();
     let event_1 = Event::from([
         ("TargetFilename", "C:\\temp\\file.au3"),
         ("Image", "C:\\temp\\autoit4.exe"),

--- a/src/basevalue.rs
+++ b/src/basevalue.rs
@@ -144,15 +144,15 @@ impl TryFrom<serde_json::Value> for BaseValue {
     }
 }
 
-impl TryFrom<serde_yml::Value> for BaseValue {
+impl TryFrom<yaml_serde::Value> for BaseValue {
     type Error = ParserError;
 
-    fn try_from(value: serde_yml::Value) -> Result<Self, Self::Error> {
+    fn try_from(value: yaml_serde::Value) -> Result<Self, Self::Error> {
         match value {
-            serde_yml::Value::Bool(b) => Ok(Self::Boolean(b)),
-            serde_yml::Value::Number(n) => number!(n),
-            serde_yml::Value::String(s) => Ok(Self::String(s)),
-            serde_yml::Value::Null => Ok(Self::Null),
+            yaml_serde::Value::Bool(b) => Ok(Self::Boolean(b)),
+            yaml_serde::Value::Number(n) => number!(n),
+            yaml_serde::Value::String(s) => Ok(Self::String(s)),
+            yaml_serde::Value::Null => Ok(Self::Null),
             _ => Err(ParserError::InvalidYAML(format!("{:?}", value))),
         }
     }
@@ -193,7 +193,7 @@ mod tests {
         let yaml = r#"
         EventID: 18446744073709551615
 "#;
-        let v: serde_yml::Value = serde_yml::from_str(yaml).unwrap();
+        let v: yaml_serde::Value = yaml_serde::from_str(yaml).unwrap();
         let base_value = BaseValue::try_from(v["EventID"].clone()).unwrap();
         assert_eq!(base_value, BaseValue::Unsigned(18446744073709551615));
     }

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -7,8 +7,8 @@ use crate::event::Event;
 use crate::selection::Selection;
 use crate::wildcard::match_tokenized;
 use serde::Deserialize;
-use serde_yml::Value;
 use std::collections::HashMap;
+use yaml_serde::Value;
 
 #[derive(Deserialize, Debug)]
 struct DetectionProxy {
@@ -174,7 +174,7 @@ mod tests {
         let mut event = Event::from([("EventID", 6416)]);
         event.insert("RandomID", "ab");
 
-        let detection: Detection = serde_yml::from_str(detection_yaml).unwrap();
+        let detection: Detection = yaml_serde::from_str(detection_yaml).unwrap();
         assert_eq!(detection.selections.len(), 2);
         let result = detection.evaluate(&event);
         assert!(result);
@@ -202,7 +202,7 @@ mod tests {
         let mut event = Event::from([("EventID", 6416)]);
         event.insert("RandomID", "ab");
 
-        let detection: Detection = serde_yml::from_str(detection_yaml).unwrap();
+        let detection: Detection = yaml_serde::from_str(detection_yaml).unwrap();
         assert_eq!(detection.selections.len(), 2);
         let result = detection.evaluate(&event);
         assert!(result);
@@ -229,7 +229,7 @@ mod tests {
         let mut event = Event::from([("EventID", 6416)]);
         event.insert("RandomID", "ab");
 
-        let detection: Detection = serde_yml::from_str(detection_yaml).unwrap();
+        let detection: Detection = yaml_serde::from_str(detection_yaml).unwrap();
         assert_eq!(detection.selections.len(), 2);
         let result = detection.evaluate(&event);
         assert!(result);
@@ -256,7 +256,7 @@ mod tests {
         let mut event = Event::from([("EventID", 6416)]);
         event.insert("RandomID", "ab");
 
-        let detection: Detection = serde_yml::from_str(detection_yaml).unwrap();
+        let detection: Detection = yaml_serde::from_str(detection_yaml).unwrap();
         assert_eq!(detection.selections.len(), 2);
         let result = detection.evaluate(&event);
         assert!(!result);

--- a/src/field.rs
+++ b/src/field.rs
@@ -14,8 +14,8 @@ use crate::field::transformation::{encode_base64, encode_base64_offset, windash_
 use crate::wildcard::{WildcardToken, tokenize};
 use cidr::IpCidr;
 use regex::Regex;
-use serde_yml::Value;
 use std::str::FromStr;
+use yaml_serde::Value;
 
 // https://sigmahq.io/docs/basics/modifiers.html
 #[derive(Debug)]

--- a/src/field/value.rs
+++ b/src/field/value.rs
@@ -21,10 +21,10 @@ where
     }
 }
 
-impl TryFrom<serde_yml::Value> for FieldValue {
+impl TryFrom<yaml_serde::Value> for FieldValue {
     type Error = ParserError;
 
-    fn try_from(value: serde_yml::Value) -> Result<Self, Self::Error> {
+    fn try_from(value: yaml_serde::Value) -> Result<Self, Self::Error> {
         Ok(Self::Base(BaseValue::try_from(value)?))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ pub use event::Event;
 pub use rule::Rule;
 
 /// Parse a rule from a YAML string
-pub fn rule_from_yaml(yaml: &str) -> Result<Rule, serde_yml::Error> {
-    serde_yml::from_str(yaml)
+pub fn rule_from_yaml(yaml: &str) -> Result<Rule, yaml_serde::Error> {
+    yaml_serde::from_str(yaml)
 }
 
 /// Parse an event from a JSON string

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -145,7 +145,7 @@ pub struct Rule {
     pub tags: Option<Vec<String>>,
     /// Capture any additional fields
     #[serde(flatten)]
-    pub custom_fields: HashMap<String, serde_yml::Value>,
+    pub custom_fields: HashMap<String, yaml_serde::Value>,
 }
 
 impl Rule {
@@ -213,7 +213,7 @@ mod tests {
         another_custom_field:
             nested: nested_value
         "#;
-        let rule: Rule = serde_yml::from_str(rule_yaml).unwrap();
+        let rule: Rule = yaml_serde::from_str(rule_yaml).unwrap();
         assert_eq!(rule.title, "Some test title");
         assert_eq!(
             rule.id,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,8 +6,8 @@ use crate::error::SelectionError::{
 use crate::event::Event;
 use crate::field::Field;
 use serde::Deserialize;
-use serde_yml::Value;
-use serde_yml::Value::{Mapping, Sequence};
+use yaml_serde::Value;
+use yaml_serde::Value::{Mapping, Sequence};
 
 /// A field group is a collection of fields that are to be combined with AND
 /// In other words a fields group translates to a YAML dictionary
@@ -22,9 +22,9 @@ impl FieldGroup {
     }
 }
 
-impl TryFrom<serde_yml::Mapping> for FieldGroup {
+impl TryFrom<yaml_serde::Mapping> for FieldGroup {
     type Error = ParserError;
-    fn try_from(mapping: serde_yml::Mapping) -> Result<Self, Self::Error> {
+    fn try_from(mapping: yaml_serde::Mapping) -> Result<Self, Self::Error> {
         let mut fields = vec![];
         for (name, values) in mapping.into_iter() {
             match name {
@@ -132,7 +132,7 @@ mod tests {
     use crate::basevalue::BaseValue;
     use crate::event::Event;
     use crate::field::{FieldValue, MatchModifier};
-    use serde_yml::Value;
+    use yaml_serde::Value;
 
     #[test]
     fn test_keyword_selection() {
@@ -198,7 +198,7 @@ mod tests {
             - hello
     "#;
 
-        let value: Value = serde_yml::from_str(yaml).unwrap();
+        let value: Value = yaml_serde::from_str(yaml).unwrap();
         let selection = Selection::try_from(value).unwrap();
         assert!(
             matches!(selection, Selection::Keyword(kw) if kw.len() == 3 && kw[0] == "0" && kw[1] == "6" && kw[2] == "hello")
@@ -213,7 +213,7 @@ mod tests {
             - hello: world
     "#;
 
-        let value: Value = serde_yml::from_str(yaml).unwrap();
+        let value: Value = yaml_serde::from_str(yaml).unwrap();
         let err = Selection::try_from(value).unwrap_err();
         assert!(matches!(
             err,
@@ -233,7 +233,7 @@ mod tests {
             - cd
             - ed
 "#;
-        let data: serde_yml::Mapping = serde_yml::from_str(yaml).unwrap();
+        let data: yaml_serde::Mapping = yaml_serde::from_str(yaml).unwrap();
         assert_eq!(data.len(), 1);
 
         let value = data.values().next().unwrap().clone();

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -12,7 +12,7 @@ detection:
         - 'evil'
     condition: keywords
 "#;
-    let rule: Rule = serde_yml::from_str(yaml).unwrap();
+    let rule: Rule = yaml_serde::from_str(yaml).unwrap();
     let event_1 = Event::from([("a", "this is hello world "), ("os", "is windows")]);
     let event_2 = Event::from([("b", "this is arch linux!"), ("more", "something")]);
     let event_3 = Event::from([("c", "evil"), ("more", "something")]);
@@ -38,7 +38,7 @@ detection:
         b: chuck
     condition: keywords and selection
 "#;
-    let rule: Rule = serde_yml::from_str(yaml).unwrap();
+    let rule: Rule = yaml_serde::from_str(yaml).unwrap();
     let event_1 = Event::from([("a", "this is hello world "), ("os", "is windows")]);
     let event_2 = Event::from([("a", "test"), ("b", "chuck"), ("c", "hello world")]);
     let event_3 = Event::from([("a", "test"), ("b", "chuck")]);
@@ -71,7 +71,7 @@ fn test_match_field_list() {
             condition: selection and 1 of filter_*
     "#;
 
-    let rule: Rule = serde_yml::from_str(yaml).unwrap();
+    let rule: Rule = yaml_serde::from_str(yaml).unwrap();
 
     let event_1 = Event::from([
         ("Image", "C:\\rundll32.exe"),


### PR DESCRIPTION
`serde_yml` is unmaintained — its latest release (0.0.13) is a deprecation shim that forwards to `noyalib`.

## Why not `noyalib` (the deprecation notice's suggestion)
Rejected: `noyalib::Number` is only `Integer(i64) | Float(f64)` — **no u64**. Any value in `(i64::MAX, u64::MAX]` is parsed as a lossy `f64` and corrupted at parse time (`18446744073709551615` → `1.84e19`), which silently changes matching on large unsigned values. Unrecoverable, and the crate is bloated (`robotics`/`i18n`/`tokio_async` modules).

## Why `yaml_serde`
`yaml_serde` is the **actively maintained fork of `serde_yaml`, published by the official YAML organization** ([github.com/yaml/yaml-serde](https://github.com/yaml/yaml-serde)) — the most credible steward for a YAML library (vs the archived original `serde_yaml`, or single-maintainer forks). It is a **pure drop-in**: this change is just a `serde_yml` → `yaml_serde` rename with no API adjustments, and correct u64 handling.

Also fixes two clippy lints (`for_kv_map`, `unnecessary_unwrap`) that CI's `RUSTFLAGS=-Dwarnings` promotes to errors.

## Verification (all local, exact CI commands)
- `cargo build --all-targets` (`-Dwarnings`) ✅
- `cargo test` — including parsing the **3,040 SigmaHQ r2024-09-02 rules** ✅
- `cargo test --no-default-features` ✅
- `cargo clippy --all-targets --all-features` (`-Dwarnings`) ✅
- `cargo fmt --all -- --check` ✅

Separate from #5 (deps + edition-2024 bump), which deliberately kept `serde_yml` 0.0.12 pending this decision. Supersedes #6 (which targeted serde_yaml_ng). If #5 merges first there's a trivial one-line `Cargo.toml` conflict (keep `yaml_serde`).